### PR TITLE
Support immutable release with tagpr draft + GoReleaser

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -79,3 +79,4 @@
 	vPrefix = true
 	releaseBranch = master
 	versionFile = -
+	release = draft


### PR DESCRIPTION
## Summary
- Set `tagpr.release = draft` so tagpr creates a draft release
- GoReleaser picks up the draft via `release.use_existing_draft: true`, adds assets, and publishes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)