### PR TITLE
Add -authorization-header flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Prometheus query plugin for Mackerel.
 
 ```
 Usage of mackerel-plugin-prometheus-query:
-Usage of ./mackerel-plugin-prometheus-query:
   -address string
     	Prometheus address (default "http://localhost:9090")
+  -authorization-header string
+    	Authorization header value (e.g. "Bearer TOKEN")
   -emit-zero
     	emit 0 when query returns no result
   -metric-key-format string

--- a/lib/prometheus.go
+++ b/lib/prometheus.go
@@ -3,6 +3,7 @@ package promq
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"regexp"
 	"strconv"
@@ -21,11 +22,12 @@ var unmachedLabel = "_"
 
 // Plugin mackerel plugin for prometheus query
 type Plugin struct {
-	Address  string
-	Format   string
-	Query    string
-	Timeout  time.Duration
-	EmitZero bool
+	Address             string
+	Format              string
+	Query               string
+	Timeout             time.Duration
+	EmitZero            bool
+	AuthorizationHeader string
 }
 
 type metric struct {
@@ -40,8 +42,26 @@ func (m *metric) String() string {
 	return strings.Join([]string{m.key, value, ts}, "\t")
 }
 
+type authorizationRoundTripper struct {
+	header string
+	rt     http.RoundTripper
+}
+
+func (a *authorizationRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r2 := r.Clone(r.Context())
+	r2.Header.Set("Authorization", a.header)
+	return a.rt.RoundTrip(r2)
+}
+
 func (p Plugin) fetch(ctx context.Context) ([]*metric, error) {
-	client, err := prometheus.NewClient(prometheus.Config{Address: p.Address})
+	cfg := prometheus.Config{Address: p.Address}
+	if p.AuthorizationHeader != "" {
+		cfg.RoundTripper = &authorizationRoundTripper{
+			header: p.AuthorizationHeader,
+			rt:     http.DefaultTransport,
+		}
+	}
+	client, err := prometheus.NewClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to new client for prometheus API: %w", err)
 	}

--- a/lib/prometheus_test.go
+++ b/lib/prometheus_test.go
@@ -1,6 +1,10 @@
 package promq
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +20,73 @@ func TestMetric(t *testing.T) {
 	}
 	if m.String() != "foo.bar\t123.456\t1575944553" {
 		t.Error("unexpected metric string", m.String())
+	}
+}
+
+func TestAuthorizationHeader(t *testing.T) {
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		// Return a valid empty vector response
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer ts.Close()
+
+	p := Plugin{
+		Address:             ts.URL,
+		Format:              "test",
+		Query:               "up",
+		Timeout:             10 * time.Second,
+		AuthorizationHeader: "Bearer my-secret-token",
+	}
+	_, err := p.fetch(context.Background())
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if gotAuth != "Bearer my-secret-token" {
+		t.Errorf("expected Authorization header 'Bearer my-secret-token', got '%s'", gotAuth)
+	}
+}
+
+func TestNoAuthorizationHeader(t *testing.T) {
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer ts.Close()
+
+	p := Plugin{
+		Address: ts.URL,
+		Format:  "test",
+		Query:   "up",
+		Timeout: 10 * time.Second,
+	}
+	_, err := p.fetch(context.Background())
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if gotAuth != "" {
+		t.Errorf("expected no Authorization header, got '%s'", gotAuth)
+	}
+}
+
+func TestAuthorizationHeaderNotInErrorMessage(t *testing.T) {
+	p := Plugin{
+		Address:             "http://localhost:1", // connection refused
+		Format:              "test",
+		Query:               "up",
+		Timeout:             1 * time.Second,
+		AuthorizationHeader: "Bearer my-secret-token",
+	}
+	_, err := p.fetch(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if strings.Contains(err.Error(), "my-secret-token") {
+		t.Error("error message should not contain the token")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func run() error {
 	optQuery := flag.String("query", "", "PromQL query")
 	optTimeout := flag.String("timeout", "10s", "timeout for query")
 	optEmitZero := flag.Bool("emit-zero", false, "emit 0 when query returns no result")
+	optAuthHeader := flag.String("authorization-header", "", "Authorization header value (e.g. \"Bearer TOKEN\")")
 	flag.Parse()
 
 	to, err := time.ParseDuration(*optTimeout)
@@ -31,11 +32,12 @@ func run() error {
 	}
 
 	p := promq.Plugin{
-		Address:  *optAddress,
-		Format:   *optFormat,
-		Query:    *optQuery,
-		Timeout:  to,
-		EmitZero: *optEmitZero,
+		Address:             *optAddress,
+		Format:              *optFormat,
+		Query:               *optQuery,
+		Timeout:             to,
+		EmitZero:            *optEmitZero,
+		AuthorizationHeader: *optAuthHeader,
 	}
 
 	return p.Run(context.Background())


### PR DESCRIPTION
## Summary
- Add `-authorization-header` flag to set the Authorization header value for Prometheus API requests
- The value is sent as-is (e.g. `"Bearer TOKEN"`, `"Basic xxx"`), so any auth scheme can be used
- Uses a custom RoundTripper to inject the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)